### PR TITLE
Simplify Parsed Decimals

### DIFF
--- a/src/helper/parseInput.ts
+++ b/src/helper/parseInput.ts
@@ -54,12 +54,7 @@ export function parseInput(input: number | string): { numerator: number; denomin
   if (/^\d+\.\d+$/.test(value)) {
     let decimal = parseFloat(value);
     if (isNaN(decimal)) throw new FractionError(`Invalid decimal: ${value}`);
-    let denominator = 1;
-    while (decimal % 1 !== 0) {
-      decimal *= 10;
-      denominator *= 10;
-    }
-    return { numerator: isNegative ? -decimal : decimal, denominator };
+    return getLowestFraction(isNegative ? -decimal : decimal)
   }
 
   // Handle numeric input directly (e.g., 2, -0.5)
@@ -67,14 +62,33 @@ export function parseInput(input: number | string): { numerator: number; denomin
     if (Number.isInteger(input)) {
       return { numerator: input, denominator: 1 };
     }
-    let decimal = input;
-    let denominator = 1;
-    while (decimal % 1 !== 0) {
-      decimal *= 10;
-      denominator *= 10;
-    }
-    return { numerator: decimal, denominator };
+    return getLowestFraction(input)
   }
-
+  
   throw new FractionError(`Invalid input format: ${input}`);
+}
+
+function getLowestFraction(decimal: number) {
+  // Source: https://stackoverflow.com/a - Posted by Martin R, modified by community. - License - CC BY-SA 3.0
+  // TODO: pass in the precision optionally
+  var eps = 1.0E-15; // precision, this default roughly corresponds to the number of significant digits of a double precision number
+  var h, h1, h2, k, k1, k2, a, x;
+  
+  x = decimal;
+  a = Math.floor(x);
+  h1 = 1;
+  k1 = 0;
+  h = a;
+  k = 1;
+  
+  while (x-a > eps*k*k) {
+    x = 1/(x-a);
+    a = Math.floor(x);
+    h2 = h1; h1 = h;
+    k2 = k1; k1 = k;
+    h = h2 + a*h1;
+    k = k2 + a*k1;
+  }
+  
+  return {numerator: h, denominator: k};
 }

--- a/src/helper/parseInput.ts
+++ b/src/helper/parseInput.ts
@@ -68,27 +68,29 @@ export function parseInput(input: number | string): { numerator: number; denomin
   throw new FractionError(`Invalid input format: ${input}`);
 }
 
-function getLowestFraction(decimal: number) {
-  // Source: https://stackoverflow.com/a - Posted by Martin R, modified by community. - License - CC BY-SA 3.0
-  // TODO: pass in the precision optionally
-  var eps = 1.0E-15; // precision, this default roughly corresponds to the number of significant digits of a double precision number
-  var h, h1, h2, k, k1, k2, a, x;
+/**
+ * Gets the lowest fraction that a number was trying to represent.
+ * @param decimal - the number we're turning into a fraction
+ * @param precision - this default roughly corresponds to the number of significant digits of a double precision number
+ * @license CC BY-SA 3.0
+ * @see https://stackoverflow.com/a/14011299 Posted by Martin R, modified by community.
+*/
+function getLowestFraction(decimal: number, precision = 1.0E-15) {
+  let remaining = decimal
+  let integerPart = Math.floor(remaining)
+  let previousNumerator = 1
+  let previousDenominator = 0
+  let numerator = integerPart
+  let denominator = 1
   
-  x = decimal;
-  a = Math.floor(x);
-  h1 = 1;
-  k1 = 0;
-  h = a;
-  k = 1;
-  
-  while (x-a > eps*k*k) {
-    x = 1/(x-a);
-    a = Math.floor(x);
-    h2 = h1; h1 = h;
-    k2 = k1; k1 = k;
-    h = h2 + a*h1;
-    k = k2 + a*k1;
+  while (remaining - integerPart > precision * denominator * denominator) {
+    remaining = 1 / (remaining - integerPart)
+    integerPart = Math.floor(remaining)
+    let temporaryNumerator = previousNumerator; previousNumerator = numerator
+    let temporaryDenominator = previousDenominator; previousDenominator = denominator
+    numerator = temporaryNumerator + integerPart * previousNumerator
+    denominator = temporaryDenominator + integerPart * previousDenominator
   }
   
-  return {numerator: h, denominator: k};
+  return {numerator, denominator};
 }

--- a/tests/parseInput.test.ts
+++ b/tests/parseInput.test.ts
@@ -29,8 +29,13 @@ describe('parseInput', () => {
   });
 
   test('parses positive decimals correctly', () => {
-    expect(parseInput('0.5')).toEqual({ numerator: 5, denominator: 10 });
-    expect(parseInput(0.25)).toEqual({ numerator: 25, denominator: 100 });
+    expect(parseInput('0.5')).toEqual({ numerator: 1, denominator: 2 });
+    expect(parseInput(0.25)).toEqual({ numerator: 1, denominator: 4 });
+    expect(parseInput('0.2500')).toEqual({ numerator: 1, denominator: 4 });
+    expect(parseInput(0.1875)).toEqual({ numerator: 3, denominator: 16 });
+    expect(parseInput(0.3333333333333333)).toEqual({ numerator: 1, denominator: 3 });
+    expect(parseInput(0.14285714285714285)).toEqual({ numerator: 1, denominator: 7 });
+    expect(parseInput(Math.PI)).toEqual({ numerator: 80143857, denominator: 25510582 });
   });
 
   // Negative input tests
@@ -60,10 +65,15 @@ describe('parseInput', () => {
   });
 
   test('parses negative decimals correctly', () => {
-    expect(parseInput('-0.5')).toEqual({ numerator: -5, denominator: 10 });
-    expect(parseInput(-0.25)).toEqual({ numerator: -25, denominator: 100 });
+    expect(parseInput('-0.5')).toEqual({ numerator: -1, denominator: 2 });
+    expect(parseInput(-0.25)).toEqual({ numerator: -1, denominator: 4 });
+    expect(parseInput('-0.2500')).toEqual({ numerator: -1, denominator: 4 });
+    expect(parseInput(-0.1875)).toEqual({ numerator: -3, denominator: 16 });
+    expect(parseInput(-0.3333333333333333)).toEqual({ numerator: -1, denominator: 3 });
+    expect(parseInput(-0.14285714285714285)).toEqual({ numerator: -1, denominator: 7 });
+    expect(parseInput(-Math.PI)).toEqual({ numerator: -80143857, denominator: 25510582 });
   });
-
+  
   // Edge cases
   test('handles zero correctly', () => {
     expect(parseInput('0')).toEqual({ numerator: 0, denominator: 1 });


### PR DESCRIPTION
I am in a situation where I want to store numbers as actual numbers, not strings, but when I read them and write them I want to use the fraction strings. This update to the parse logic will take a js number and turn it into whatever fraction it was intending to represent (up to a certain precision, good for most use cases).

Currently: `1.3333333333333333` → `"1 3333333333333333/10000000000000000"`
Change: `1.3333333333333333` → `"1 1/3"`

The existing tests still pass, and I added some new tests.